### PR TITLE
Hadoop lzo support

### DIFF
--- a/manifests/hadoop.pp
+++ b/manifests/hadoop.pp
@@ -32,11 +32,12 @@
 #   $mapreduce_task_io_sort_factor
 #   $mapreduce_map_java_opts
 #   $mapreduce_child_java_opts
-#   $mapreduce_intermediate_compression   - If true, intermediate MapReduce data will be compressed with Snappy.    Default: true.
+#   $mapreduce_intermediate_compression   - If true, intermediate MapReduce data will be compressed with Snappy or LZO.    Default: true.
 #   $mapreduce_final_compession           - If true, Final output of MapReduce jobs will be compressed with Snappy. Default: false.
 #   $yarn_nodemanager_resource_memory_mb
 #   $yarn_resourcemanager_scheduler_class - If you change this (e.g. to FairScheduler), you should also provide your own scheduler config .xml files outside of the cdh4 module.
 #   $use_yarn
+#   $enable_lzo          - Enables LZO compression in Hadoop. Default: false 
 #
 class cdh4::hadoop(
   $namenode_hostname,
@@ -64,7 +65,8 @@ class cdh4::hadoop(
   $mapreduce_final_compession              = $::cdh4::hadoop::defaults::mapreduce_final_compession,
   $yarn_nodemanager_resource_memory_mb     = $::cdh4::hadoop::defaults::yarn_nodemanager_resource_memory_mb,
   $yarn_resourcemanager_scheduler_class    = $::cdh4::hadoop::defaults::yarn_resourcemanager_scheduler_class,
-  $use_yarn                                = $::cdh4::hadoop::defaults::use_yarn
+  $use_yarn                                = $::cdh4::hadoop::defaults::use_yarn,
+  $enable_lzo                              =$::cdh4::hadoop::defaults::enable_lzo
 
 ) inherits cdh4::hadoop::defaults
 {

--- a/manifests/hadoop.pp
+++ b/manifests/hadoop.pp
@@ -82,6 +82,12 @@ class cdh4::hadoop(
     ensure => 'installed'
   }
 
+  if $enable_lzo {
+    package { 'lzo':
+      ensure => 'installed'
+    }
+  }
+
   # All config files require hadoop-client package
   File {
     require => Package['hadoop-client']

--- a/manifests/hadoop/defaults.pp
+++ b/manifests/hadoop/defaults.pp
@@ -26,4 +26,5 @@ class cdh4::hadoop::defaults {
   $yarn_nodemanager_resource_memory_mb     = undef
   $yarn_resourcemanager_scheduler_class    = undef
   $use_yarn                                = true
+  $enable_lzo                              = false
 }

--- a/templates/hadoop/core-site.xml.erb
+++ b/templates/hadoop/core-site.xml.erb
@@ -45,4 +45,14 @@
   </property>
 <% end -%>
 
+<% if @enable_lzo -%>
+  <property>
+    <name>io.compression.codecs</name>
+    <value>org.apache.hadoop.io.compress.GzipCodec,org.apache.hadoop.io.compress.DefaultCodec,org.apache.hadoop.io.compress.BZip2Codec,com.hadoop.compression.lzo.LzoCodec,com.hadoop.compression.lzo.LzopCodec</value>
+  </property>
+  <property>
+    <name>io.compression.codec.lzo.class</name>
+    <value>com.hadoop.compression.lzo.LzoCodec</value>
+  </property>
+<% end -%>
 </configuration>

--- a/templates/hadoop/mapred-site.xml.erb
+++ b/templates/hadoop/mapred-site.xml.erb
@@ -122,7 +122,11 @@
   </property>
   <property>
     <name>mapreduce.map.output.compress.codec</name>
+<%if @enable_lzo -%>
+    <value>com.hadoop.compression.lzo.LzoCodec</value>
+<% else -%>
     <value>org.apache.hadoop.io.compress.SnappyCodec</value>
+<% end -%>
   </property>
 
   <!-- MapReduce final output compression -->


### PR DESCRIPTION
Enable it with 
class { "cdh4::hadoop":
          enable_lzo  => true
}

If enabled, the default intermediate compression of 'snappy' is switched to lzo.

You still have to compile lzo module yourself and put it into /usr/lib/hadoop/lib and the native binaries to /usr/lib/hadoop/lib/native/
Or even easier, use Clouderas RPMs as shown here http://www.devops-blog.net/hadoop/installing-hadoop-lzo-compression-module-rpms
