### PR TITLE
HBase support

### DIFF
--- a/manifests/hadoop/directory.pp
+++ b/manifests/hadoop/directory.pp
@@ -34,7 +34,7 @@ define cdh4::hadoop::directory (
   $group  = 'hdfs',
   $mode   = '0755')
 {
-  Class['cdh4::hadoop'] -> Cdh4::Hadoop::Directory[$title]
+#  Class['cdh4::hadoop'] -> Cdh4::Hadoop::Directory[$title]
 
   if $ensure == 'present' {
     exec { "cdh4::hadoop::directory ${title}":

--- a/manifests/hbase.pp
+++ b/manifests/hbase.pp
@@ -1,0 +1,18 @@
+# == Class cdh4::hbase
+#
+# Installs HBase packages needed for server and region-servers
+#
+class cdh4::hbase(
+  $root_dir         = $::cdh4::hbase::defaults::root_dir,
+  $config_directory = $::cdh4::hbase::defaults::config_directory,
+  $master_domain    = $::cdh4::hbase::defaults::master_domain,
+) inherits cdh4::hbase::defaults 
+{
+  package { 'hbase':
+    ensure => 'installed',
+  }
+
+  file { "${config_directory}/hbase-site.xml":
+    content => template('cdh4/hbase/hbase-site.xml.erb'),
+  }
+}

--- a/manifests/hbase.pp
+++ b/manifests/hbase.pp
@@ -6,6 +6,7 @@ class cdh4::hbase(
   $root_dir         = $::cdh4::hbase::defaults::root_dir,
   $config_directory = $::cdh4::hbase::defaults::config_directory,
   $master_domain    = $::cdh4::hbase::defaults::master_domain,
+  $zookeeper_master = $::cdh4::hbase::defaults::zookeeper_master,
 ) inherits cdh4::hbase::defaults 
 {
   package { 'hbase':

--- a/manifests/hbase/defaults.pp
+++ b/manifests/hbase/defaults.pp
@@ -1,0 +1,8 @@
+# == Class cdh4::hbase::defaults
+# Default parameters for cdh4::hbase configuration.
+#
+class cdh4::hbase::defaults {
+  $root_dir         = '/hbase'
+  $config_directory = '/etc/hbase/conf'
+  $master_domain    = undef
+}

--- a/manifests/hbase/defaults.pp
+++ b/manifests/hbase/defaults.pp
@@ -5,4 +5,5 @@ class cdh4::hbase::defaults {
   $root_dir         = '/hbase'
   $config_directory = '/etc/hbase/conf'
   $master_domain    = undef
+  $zookeeper_master = undef
 }

--- a/manifests/hbase/master.pp
+++ b/manifests/hbase/master.pp
@@ -1,0 +1,27 @@
+# == Class cdh4::hbase::master
+# Installs HBase master
+#
+class cdh4::hbase::master {
+
+  Class['cdh4::hbase'] -> Class['cdh4::hbase::master']
+
+  package { 'hbase-master': 
+    ensure => 'installed',
+  }
+
+  service { 'hbase-master':
+    ensure      => 'running',
+    enable      => true,
+    hasrestart  => true,
+    require     => File["${::cdh4::hbase::config_directory}/hbase-site.xml"],
+    subscribe   => File["${::cdh4::hbase::config_directory}/hbase-site.xml"],
+  }
+
+  # sudo -u hdfs hadoop fs -mkdir /hbase
+  # sudo -u hdfs hadoop fs -chown hbase /hbase
+  cdh4::hadoop::directory { "${::cdh4::hbase::root_dir}":
+    owner   => 'hbase',
+    group   => 'hbase',
+  }
+
+}

--- a/manifests/hbase/regionserver.pp
+++ b/manifests/hbase/regionserver.pp
@@ -1,0 +1,20 @@
+# == Class cdh4::hbase::master
+# Installs HBase regionserver
+#
+class cdh4::hbase::regionserver {
+
+  Class['cdh4::hbase'] -> Class['cdh4::hbase::regionserver']
+
+  package { 'hbase-regionserver': 
+    ensure => 'installed',
+  }
+
+  service { 'hbase-regionserver':
+    ensure      => 'running',
+    enable      => true,
+    hasrestart  => true,
+    require     => File["${::cdh4::hbase::config_directory}/hbase-site.xml"],
+    subscribe   => File["${::cdh4::hbase::config_directory}/hbase-site.xml"],
+  }
+
+}

--- a/templates/hbase/hbase-site.xml.erb
+++ b/templates/hbase/hbase-site.xml.erb
@@ -30,4 +30,10 @@
     <name>hbase.rootdir</name>
     <value>hdfs://<%= @master_domain %>:8020<%= @root_dir %></value>
 </property>
+<% if @zookeeper_master -%>
+<property>
+    <name>hbase.zookeeper.quorum</name>
+    <value><%= @zookeeper_master %></value>
+</property>
+<% end -%>
 </configuration>

--- a/templates/hbase/hbase-site.xml.erb
+++ b/templates/hbase/hbase-site.xml.erb
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+/**
+ * Copyright 2010 The Apache Software Foundation
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<configuration>
+<property>
+    <name>hbase.cluster.distributed</name>
+    <value>true</value>
+</property>
+<property>
+    <name>hbase.rootdir</name>
+    <value>hdfs://<%= @master_domain %>:8020<%= @root_dir %></value>
+</property>
+</configuration>


### PR DESCRIPTION
Added HBase support. Configuration is very basic so far.

Prereq:
Have Zookeeper server up and running manually or by puppet.

Usage:
On HBase-Master:

```
class {'cdh4::hbase':
    master_domain => 'hbase-master.domain.com',
}
include cdh4::hbase::master
```

On HBase-Regionservers:

```
class {'cdh4::hbase':
    master_domain       => 'hbase-master.domain.com',
    zookeeper_master    => 'zookeeper-master.domain.com',
}
include cdh4::hbase::regionserver
```

You can also install/include both master and regionserver on the same host. HBase will then run in pseudo-distributed mode.
